### PR TITLE
ツイート投稿機能実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,4 +2,17 @@ class TweetsController < ApplicationController
   def index
     @tweets = Tweet.all
   end
+
+  def new
+    @tweet = Tweet.new
+  end
+
+  def create
+    Tweet.create(tweet_params)
+  end
+
+  private
+  def tweet_params
+    params.require(:tweet).permit(:name, :text)
+  end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -9,6 +9,7 @@ class TweetsController < ApplicationController
 
   def create
     Tweet.create(tweet_params)
+    redirect_to "/"
   end
 
   private

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,2 +1,3 @@
 class Tweet < ApplicationRecord
+  validates :text, presence: true
 end

--- a/app/views/tweets/create.html.erb
+++ b/app/views/tweets/create.html.erb
@@ -1,4 +1,0 @@
-<div class="success">
-  <h3>投稿が完了しました。 </h3>
-  <a class="btn" href="/tweets">投稿一覧へ戻る</a>
-</div>

--- a/app/views/tweets/create.html.erb
+++ b/app/views/tweets/create.html.erb
@@ -1,0 +1,4 @@
+<div class="success">
+  <h3>投稿が完了しました。 </h3>
+  <a class="btn" href="/tweets">投稿一覧へ戻る</a>
+</div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+  <%= form_with(model: @tweet, local: true) do |form| %>
+    <h3>投稿する</h3>
+    <%= form.text_field :name, placeholder: "Nickname" %>
+    <%= form.text_area :text, placeholder: "text" , rows: "10" %>
+    <%= form.submit "SEND" %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :tweets, only: :index
+  root to: 'tweets#index'
+  resources :tweets, only: [:index, :new, :create]
 end


### PR DESCRIPTION
# 概要
ツイート投稿機能の実装

## 実装内容
・#new、#createのルーティングを設定
・#new、#createをコントローラに定義
・ツイート新規投稿画面を追加
・ツイート投稿後のビューを追加
・空フォームを弾くようにバリデーションを設定


## 実装結果
### ツイート新規作成画面
<img width="473" alt="スクリーンショット 2020-07-06 12 23 26" src="https://user-images.githubusercontent.com/46119001/86552621-8159fa00-bf83-11ea-8d9b-888e5daf6ccc.png">

### ツイート投稿後のビュー
<img width="473" alt="スクリーンショット 2020-07-06 12 24 18" src="https://user-images.githubusercontent.com/46119001/86552658-9f275f00-bf83-11ea-8d1d-7d3d1475b0ce.png">


## 特に確認して欲しい箇所
・new.html.erbとcreate.html.erbに不要な記述がないかを確認して頂きたいです